### PR TITLE
Fixes issue for none square inputs for Sweep Motif

### DIFF
--- a/mpi/sweep3d/sweep3d.c
+++ b/mpi/sweep3d/sweep3d.c
@@ -192,7 +192,7 @@ int main(int argc, char* argv[]) {
       }
 
       if (yUp > -1) {
-        MPI_Send(ySendBuffer, (nx * kba * vars), MPI_DOUBLE, yUp, 1000,
+        MPI_Send(ySendBuffer, (ny * kba * vars), MPI_DOUBLE, yUp, 1000,
                  MPI_COMM_WORLD);
       }
     }
@@ -217,7 +217,7 @@ int main(int argc, char* argv[]) {
       }
 
       if (yUp > -1) {
-        MPI_Send(ySendBuffer, (nx * kba * vars), MPI_DOUBLE, yUp, 2000,
+        MPI_Send(ySendBuffer, (ny * kba * vars), MPI_DOUBLE, yUp, 2000,
                  MPI_COMM_WORLD);
       }
     }
@@ -242,7 +242,7 @@ int main(int argc, char* argv[]) {
       }
 
       if (yDown > -1) {
-        MPI_Send(ySendBuffer, (nx * kba * vars), MPI_DOUBLE, yDown, 3000,
+        MPI_Send(ySendBuffer, (ny * kba * vars), MPI_DOUBLE, yDown, 3000,
                  MPI_COMM_WORLD);
       }
     }
@@ -267,7 +267,7 @@ int main(int argc, char* argv[]) {
       }
 
       if (yDown > -1) {
-        MPI_Send(ySendBuffer, (nx * kba * vars), MPI_DOUBLE, yDown, 4000,
+        MPI_Send(ySendBuffer, (ny * kba * vars), MPI_DOUBLE, yDown, 4000,
                  MPI_COMM_WORLD);
       }
     }


### PR DESCRIPTION
When nx != ny  the Sweep3D motif fails because the send length for the y dimension was calculated with nx instead of ny. 