### PR TITLE
Fix compilation errors in mpi/halo3d* and mpi/sweep3d

### DIFF
--- a/mpi/halo3d-26/Makefile
+++ b/mpi/halo3d-26/Makefile
@@ -1,10 +1,11 @@
 
 CC=mpicc
 CFLAGS=-O3 -std=c99
+EXTRA_CFLAGS=-D_POSIX_C_SOURCE=200809L
 LIBS=
 
 halo3d-26: halo3d-26.c
-	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $< $(LIBS)
 
 clean:
 	rm halo3d-26

--- a/mpi/halo3d/Makefile
+++ b/mpi/halo3d/Makefile
@@ -1,10 +1,11 @@
 
 CC=mpicc
 CFLAGS=-O3 -std=c99
+EXTRA_CFLAGS=-D_POSIX_C_SOURCE=200809L
 LIBS=
 
 halo3d: halo3d.c
-	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $< $(LIBS)
 
 clean:
 	rm halo3d

--- a/mpi/sweep3d/Makefile
+++ b/mpi/sweep3d/Makefile
@@ -1,10 +1,11 @@
 
 CC=mpicc
 CFLAGS=-O3 -std=c99
+EXTRA_CFLAGS=-D_POSIX_C_SOURCE=200809L
 LIBS=
 
 sweep3d: sweep3d.c
-	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $< $(LIBS)
 
 clean:
 	rm sweep3d


### PR DESCRIPTION
Add -D_POSIX_C_SOURCE=200809L to fix the following:
* error: variable has incomplete type 'struct timespec'
* warning: implicit declaration of function 'nanosleep' is invalid in C99

Tested using the following compilers on Fedora 30, Fedora 33:
* gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
* gcc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)
* clang version 8.0.0 (Fedora 8.0.0-3.fc30)

Please see: https://man7.org/linux/man-pages//man2/nanosleep.2.html